### PR TITLE
Treat bad requests separately from other errors

### DIFF
--- a/hystrix/hystrix.go
+++ b/hystrix/hystrix.go
@@ -20,6 +20,29 @@ func (e CircuitError) Error() string {
 	return "hystrix: " + e.Message
 }
 
+// A BadRequest is an error which is treated as a successful call.
+// The fallback function will not be executed when a BadRequest is returned.
+// BadRequests do not count against failure metrics
+type BadRequest interface {
+	error
+	BadRequest()
+}
+
+type badRequest struct {
+	error
+}
+
+func (br badRequest) BadRequest() {
+	return
+}
+
+// NewBadRequest wraps the specified error such that it satisfies the BadRequest interface
+func NewBadRequest(err error) BadRequest {
+	return badRequest{
+		error: err,
+	}
+}
+
 // command models the state used for a single execution on a circuit. "hystrix command" is commonly
 // used to describe the pairing of your run/fallback functions with a circuit.
 type command struct {
@@ -140,7 +163,9 @@ func Go(name string, run runFunc, fallback fallbackFunc) chan error {
 		if !cmd.isTimedOut() {
 			cmd.setRunDuration(time.Since(runStart))
 
-			if runErr != nil {
+			if badRequest, ok := runErr.(BadRequest); ok {
+				cmd.errChan <- badRequest
+			} else if runErr != nil {
 				cmd.errorWithFallback(runErr)
 				return
 			}
@@ -270,14 +295,13 @@ func (c *command) tryFallback(err error) error {
 	}
 
 	fallbackErr := c.fallback(err)
-	if fallbackErr != nil {
-		c.reportEvent("fallback-failure")
-		return fmt.Errorf("fallback failed with '%v'. run error was '%v'", fallbackErr, err)
+	if _, ok := fallbackErr.(BadRequest); ok || fallbackErr == nil {
+		c.reportEvent("fallback-success")
+		return fallbackErr
 	}
 
-	c.reportEvent("fallback-success")
-
-	return nil
+	c.reportEvent("fallback-failure")
+	return fmt.Errorf("fallback failed with '%v'. run error was '%v'", fallbackErr, err)
 }
 
 func (c *command) getTicket() *struct{} {


### PR DESCRIPTION
Adding custom error interface so requests that do not represent system failures do not count against circuit metrics

Adding here since development in the original package seems to have come to a standstill

See issue in https://github.com/afex/hystrix-go/issues/72