### PR TITLE
Improve configs builder

### DIFF
--- a/hystrix/circuit_test.go
+++ b/hystrix/circuit_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/smartystreets/goconvey/convey"
 	"math/rand"
 	"testing/quick"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestGetCircuit(t *testing.T) {

--- a/hystrix/commandbuilder/command_builder.go
+++ b/hystrix/commandbuilder/command_builder.go
@@ -1,122 +1,118 @@
 package commandbuilder
 
 import (
-	"time"
+  "time"
 
-	"github.com/myteksi/hystrix-go/hystrix"
+  "github.com/myteksi/hystrix-go/hystrix"
 )
 
 // CommandBuilder builder for constructing new command
 
 type CommandBuilder struct {
-	commandName            string
-	timeout                int
-	maxConcurrentRequests  int
-	requestVolumeThreshold int
-	sleepWindow            int
-	errorPercentThreshold  int
-	// for more details refer - https://github.com/Netflix/Hystrix/wiki/Configuration#maxqueuesize
-	queueSizeRejectionThreshold *int
-	// group a number of command (circuit name) together, useful for defining ownership/alerts/monitoring
-	// ref: https://github.com/Netflix/Hystrix/wiki/How-To-Use#command-group
-	commandGroup string
+  commandName            string
+  timeout                int
+  maxConcurrentRequests  int
+  requestVolumeThreshold int
+  sleepWindow            int
+  errorPercentThreshold  int
+  // for more details refer - https://github.com/Netflix/Hystrix/wiki/Configuration#maxqueuesize
+  queueSizeRejectionThreshold *int
+  // group a number of command (circuit name) together, useful for defining ownership/alerts/monitoring
+  // ref: https://github.com/Netflix/Hystrix/wiki/How-To-Use#command-group
+  commandGroup string
 }
 
 // New Create new command
 func New(commandName string) *CommandBuilder {
-	return &CommandBuilder{
-		commandName:            commandName,
-		timeout:                hystrix.DefaultTimeout,
-		commandGroup:           commandName,
-		maxConcurrentRequests:  hystrix.DefaultMaxConcurrent,
-		requestVolumeThreshold: hystrix.DefaultVolumeThreshold,
-		sleepWindow:            hystrix.DefaultSleepWindow,
-		errorPercentThreshold:  hystrix.DefaultErrorPercentThreshold,
-	}
-}
-
-// WithTimeout modify timeout
-func (cb *CommandBuilder) WithTimeout(timeoutInMs int) *CommandBuilder {
-	if timeoutInMs == 0 {
-		timeoutInMs = hystrix.DefaultTimeout
-	}
-	cb.timeout = timeoutInMs
-	return cb
+  return &CommandBuilder{
+    commandName:                 commandName,
+    commandGroup:                "",
+    timeout:                     hystrix.DefaultTimeout,
+    maxConcurrentRequests:       hystrix.DefaultMaxConcurrent,
+    requestVolumeThreshold:      hystrix.DefaultVolumeThreshold,
+    sleepWindow:                 hystrix.DefaultSleepWindow,
+    errorPercentThreshold:       hystrix.DefaultErrorPercentThreshold,
+    queueSizeRejectionThreshold: nil, // will init later on build
+  }
 }
 
 // WithCommandGroup modify commandGroup
 func (cb *CommandBuilder) WithCommandGroup(commandGroup string) *CommandBuilder {
-	if commandGroup == "" {
-		commandGroup = cb.commandName
-	}
-	cb.commandGroup = commandGroup
-	return cb
+  if commandGroup != "" {
+    cb.commandGroup = commandGroup
+  }
+  return cb
+}
+
+// WithTimeout modify timeout
+func (cb *CommandBuilder) WithTimeout(timeoutInMs int) *CommandBuilder {
+  if timeoutInMs > 0 {
+    cb.timeout = timeoutInMs
+  }
+  return cb
 }
 
 // WithMaxConcurrentRequests modify max concurrent requests
 // if not already set, this will also set the queue size as 5 times the max concurrent requests
 func (cb *CommandBuilder) WithMaxConcurrentRequests(maxConcurrentRequests int) *CommandBuilder {
-	if maxConcurrentRequests == 0 {
-		maxConcurrentRequests = hystrix.DefaultMaxConcurrent
-	}
-	cb.maxConcurrentRequests = maxConcurrentRequests
-	if cb.queueSizeRejectionThreshold == nil {
-		queueSize := 5 * cb.maxConcurrentRequests
-		cb.queueSizeRejectionThreshold = &queueSize
-	}
-	return cb
-}
-
-// WithRequestVolumeThreshold modify request volume threshold
-func (cb *CommandBuilder) WithRequestVolumeThreshold(requestVolThreshold int) *CommandBuilder {
-	if requestVolThreshold == 0 {
-		requestVolThreshold = hystrix.DefaultVolumeThreshold
-	}
-	cb.requestVolumeThreshold = requestVolThreshold
-	return cb
-}
-
-// WithSleepWindow modify sleep window
-func (cb *CommandBuilder) WithSleepWindow(sleepWindow int) *CommandBuilder {
-	if sleepWindow == 0 {
-		sleepWindow = hystrix.DefaultSleepWindow
-	}
-	cb.sleepWindow = sleepWindow
-	return cb
+  if maxConcurrentRequests > 0 {
+    cb.maxConcurrentRequests = maxConcurrentRequests
+  }
+  return cb
 }
 
 // WithErrorPercentageThreshold modify error percentage threshold
 func (cb *CommandBuilder) WithErrorPercentageThreshold(errPercentThreshold int) *CommandBuilder {
-	if errPercentThreshold == 0 {
-		errPercentThreshold = hystrix.DefaultErrorPercentThreshold
-	}
-	cb.errorPercentThreshold = errPercentThreshold
-	return cb
+  if errPercentThreshold > 0 {
+    cb.errorPercentThreshold = errPercentThreshold
+  }
+  return cb
+}
+
+// WithRequestVolumeThreshold modify request volume threshold
+func (cb *CommandBuilder) WithRequestVolumeThreshold(requestVolThreshold int) *CommandBuilder {
+  if requestVolThreshold > 0 {
+    cb.requestVolumeThreshold = requestVolThreshold
+  }
+  return cb
+}
+
+// WithSleepWindow modify sleep window
+func (cb *CommandBuilder) WithSleepWindow(sleepWindow int) *CommandBuilder {
+  if sleepWindow > 0 {
+    cb.sleepWindow = sleepWindow
+  }
+  return cb
 }
 
 // WithQueueSize modify queue size
 func (cb *CommandBuilder) WithQueueSize(queueSize int) *CommandBuilder {
-	if queueSize == 0 {
-		zeroQueueSize := 0
-		cb.queueSizeRejectionThreshold = &zeroQueueSize
-	}
-	cb.queueSizeRejectionThreshold = &queueSize
-	return cb
+  if queueSize == 0 {
+    zeroQueueSize := 0
+    cb.queueSizeRejectionThreshold = &zeroQueueSize
+  } else if queueSize > 0 {
+    cb.queueSizeRejectionThreshold = &queueSize
+  }
+  return cb
 }
 
 // Build the command setting, Use hystrix.Initialize for setup
 func (cb *CommandBuilder) Build() *hystrix.Settings {
-	if cb.queueSizeRejectionThreshold == nil {
-		cb.queueSizeRejectionThreshold = &hystrix.DefaultQueueSizeRejectionThreshold
-	}
-	return &hystrix.Settings{
-		CommandName:                 cb.commandName,
-		QueueSizeRejectionThreshold: *cb.queueSizeRejectionThreshold,
-		ErrorPercentThreshold:       cb.errorPercentThreshold,
-		CommandGroup:                cb.commandGroup,
-		Timeout:                     time.Duration(cb.timeout * 1000000),
-		MaxConcurrentRequests:       cb.maxConcurrentRequests,
-		RequestVolumeThreshold:      uint64(cb.requestVolumeThreshold),
-		SleepWindow:                 time.Duration(cb.sleepWindow * 1000000),
-	}
+
+  // if value is not set, we'll use default 5x of max concurrent
+  if cb.queueSizeRejectionThreshold == nil {
+    queueSize := 5 * cb.maxConcurrentRequests
+    cb.queueSizeRejectionThreshold = &queueSize
+  }
+
+  return &hystrix.Settings{
+    CommandName:                 cb.commandName,
+    CommandGroup:                cb.commandGroup,
+    Timeout:                     time.Duration(cb.timeout) * time.Millisecond,
+    MaxConcurrentRequests:       cb.maxConcurrentRequests,
+    ErrorPercentThreshold:       cb.errorPercentThreshold,
+    RequestVolumeThreshold:      uint64(cb.requestVolumeThreshold),
+    SleepWindow:                 time.Duration(cb.sleepWindow) * time.Millisecond,
+    QueueSizeRejectionThreshold: *cb.queueSizeRejectionThreshold,
+  }
 }

--- a/hystrix/commandbuilder/command_builder.go
+++ b/hystrix/commandbuilder/command_builder.go
@@ -1,118 +1,118 @@
 package commandbuilder
 
 import (
-  "time"
+	"time"
 
-  "github.com/myteksi/hystrix-go/hystrix"
+	"github.com/myteksi/hystrix-go/hystrix"
 )
 
 // CommandBuilder builder for constructing new command
 
 type CommandBuilder struct {
-  commandName            string
-  timeout                int
-  maxConcurrentRequests  int
-  requestVolumeThreshold int
-  sleepWindow            int
-  errorPercentThreshold  int
-  // for more details refer - https://github.com/Netflix/Hystrix/wiki/Configuration#maxqueuesize
-  queueSizeRejectionThreshold *int
-  // group a number of command (circuit name) together, useful for defining ownership/alerts/monitoring
-  // ref: https://github.com/Netflix/Hystrix/wiki/How-To-Use#command-group
-  commandGroup string
+	commandName            string
+	timeout                int
+	maxConcurrentRequests  int
+	requestVolumeThreshold int
+	sleepWindow            int
+	errorPercentThreshold  int
+	// for more details refer - https://github.com/Netflix/Hystrix/wiki/Configuration#maxqueuesize
+	queueSizeRejectionThreshold *int
+	// group a number of command (circuit name) together, useful for defining ownership/alerts/monitoring
+	// ref: https://github.com/Netflix/Hystrix/wiki/How-To-Use#command-group
+	commandGroup string
 }
 
 // New Create new command
 func New(commandName string) *CommandBuilder {
-  return &CommandBuilder{
-    commandName:                 commandName,
-    commandGroup:                "",
-    timeout:                     hystrix.DefaultTimeout,
-    maxConcurrentRequests:       hystrix.DefaultMaxConcurrent,
-    requestVolumeThreshold:      hystrix.DefaultVolumeThreshold,
-    sleepWindow:                 hystrix.DefaultSleepWindow,
-    errorPercentThreshold:       hystrix.DefaultErrorPercentThreshold,
-    queueSizeRejectionThreshold: nil, // will init later on build
-  }
+	return &CommandBuilder{
+		commandName:                 commandName,
+		commandGroup:                "",
+		timeout:                     hystrix.DefaultTimeout,
+		maxConcurrentRequests:       hystrix.DefaultMaxConcurrent,
+		requestVolumeThreshold:      hystrix.DefaultVolumeThreshold,
+		sleepWindow:                 hystrix.DefaultSleepWindow,
+		errorPercentThreshold:       hystrix.DefaultErrorPercentThreshold,
+		queueSizeRejectionThreshold: nil, // will init later on build
+	}
 }
 
 // WithCommandGroup modify commandGroup
 func (cb *CommandBuilder) WithCommandGroup(commandGroup string) *CommandBuilder {
-  if commandGroup != "" {
-    cb.commandGroup = commandGroup
-  }
-  return cb
+	if commandGroup != "" {
+		cb.commandGroup = commandGroup
+	}
+	return cb
 }
 
 // WithTimeout modify timeout
 func (cb *CommandBuilder) WithTimeout(timeoutInMs int) *CommandBuilder {
-  if timeoutInMs > 0 {
-    cb.timeout = timeoutInMs
-  }
-  return cb
+	if timeoutInMs > 0 {
+		cb.timeout = timeoutInMs
+	}
+	return cb
 }
 
 // WithMaxConcurrentRequests modify max concurrent requests
 // if not already set, this will also set the queue size as 5 times the max concurrent requests
 func (cb *CommandBuilder) WithMaxConcurrentRequests(maxConcurrentRequests int) *CommandBuilder {
-  if maxConcurrentRequests > 0 {
-    cb.maxConcurrentRequests = maxConcurrentRequests
-  }
-  return cb
+	if maxConcurrentRequests > 0 {
+		cb.maxConcurrentRequests = maxConcurrentRequests
+	}
+	return cb
 }
 
 // WithErrorPercentageThreshold modify error percentage threshold
 func (cb *CommandBuilder) WithErrorPercentageThreshold(errPercentThreshold int) *CommandBuilder {
-  if errPercentThreshold > 0 {
-    cb.errorPercentThreshold = errPercentThreshold
-  }
-  return cb
+	if errPercentThreshold > 0 {
+		cb.errorPercentThreshold = errPercentThreshold
+	}
+	return cb
 }
 
 // WithRequestVolumeThreshold modify request volume threshold
 func (cb *CommandBuilder) WithRequestVolumeThreshold(requestVolThreshold int) *CommandBuilder {
-  if requestVolThreshold > 0 {
-    cb.requestVolumeThreshold = requestVolThreshold
-  }
-  return cb
+	if requestVolThreshold > 0 {
+		cb.requestVolumeThreshold = requestVolThreshold
+	}
+	return cb
 }
 
 // WithSleepWindow modify sleep window
 func (cb *CommandBuilder) WithSleepWindow(sleepWindow int) *CommandBuilder {
-  if sleepWindow > 0 {
-    cb.sleepWindow = sleepWindow
-  }
-  return cb
+	if sleepWindow > 0 {
+		cb.sleepWindow = sleepWindow
+	}
+	return cb
 }
 
 // WithQueueSize modify queue size
 func (cb *CommandBuilder) WithQueueSize(queueSize int) *CommandBuilder {
-  if queueSize == 0 {
-    zeroQueueSize := 0
-    cb.queueSizeRejectionThreshold = &zeroQueueSize
-  } else if queueSize > 0 {
-    cb.queueSizeRejectionThreshold = &queueSize
-  }
-  return cb
+	if queueSize == 0 {
+		zeroQueueSize := 0
+		cb.queueSizeRejectionThreshold = &zeroQueueSize
+	} else if queueSize > 0 {
+		cb.queueSizeRejectionThreshold = &queueSize
+	}
+	return cb
 }
 
 // Build the command setting, Use hystrix.Initialize for setup
 func (cb *CommandBuilder) Build() *hystrix.Settings {
 
-  // if value is not set, we'll use default 5x of max concurrent
-  if cb.queueSizeRejectionThreshold == nil {
-    queueSize := 5 * cb.maxConcurrentRequests
-    cb.queueSizeRejectionThreshold = &queueSize
-  }
+	// if value is not set, we'll use default 5x of max concurrent
+	if cb.queueSizeRejectionThreshold == nil {
+		queueSize := 5 * cb.maxConcurrentRequests
+		cb.queueSizeRejectionThreshold = &queueSize
+	}
 
-  return &hystrix.Settings{
-    CommandName:                 cb.commandName,
-    CommandGroup:                cb.commandGroup,
-    Timeout:                     time.Duration(cb.timeout) * time.Millisecond,
-    MaxConcurrentRequests:       cb.maxConcurrentRequests,
-    ErrorPercentThreshold:       cb.errorPercentThreshold,
-    RequestVolumeThreshold:      uint64(cb.requestVolumeThreshold),
-    SleepWindow:                 time.Duration(cb.sleepWindow) * time.Millisecond,
-    QueueSizeRejectionThreshold: *cb.queueSizeRejectionThreshold,
-  }
+	return &hystrix.Settings{
+		CommandName:                 cb.commandName,
+		CommandGroup:                cb.commandGroup,
+		Timeout:                     time.Duration(cb.timeout) * time.Millisecond,
+		MaxConcurrentRequests:       cb.maxConcurrentRequests,
+		ErrorPercentThreshold:       cb.errorPercentThreshold,
+		RequestVolumeThreshold:      uint64(cb.requestVolumeThreshold),
+		SleepWindow:                 time.Duration(cb.sleepWindow) * time.Millisecond,
+		QueueSizeRejectionThreshold: *cb.queueSizeRejectionThreshold,
+	}
 }

--- a/plugins/datadog_collector.go
+++ b/plugins/datadog_collector.go
@@ -106,8 +106,14 @@ func NewDatadogCollector(addr, prefix string) (func(string, string) metricCollec
 // "github.com/DataDog/datadog-go/statsd".(*Client), provide additional tags per
 // circuit-metric tuple, and add logging if you need it.
 func NewDatadogCollectorWithClient(client DatadogClient) func(string, string) metricCollector.MetricCollector {
-
 	return func(name string, commandGroup string) metricCollector.MetricCollector {
+    // there's no need to report the tag if it is already empty
+    if commandGroup == "" {
+      return &DatadogCollector{
+        client: client,
+        tags:   []string{"hystrixcircuit:" + name},
+      }
+    }
 		return &DatadogCollector{
 			client: client,
 			tags:   []string{"hystrixcircuit:" + name, "commandGroup:" + commandGroup},

--- a/plugins/datadog_collector.go
+++ b/plugins/datadog_collector.go
@@ -107,13 +107,13 @@ func NewDatadogCollector(addr, prefix string) (func(string, string) metricCollec
 // circuit-metric tuple, and add logging if you need it.
 func NewDatadogCollectorWithClient(client DatadogClient) func(string, string) metricCollector.MetricCollector {
 	return func(name string, commandGroup string) metricCollector.MetricCollector {
-    // there's no need to report the tag if it is already empty
-    if commandGroup == "" {
-      return &DatadogCollector{
-        client: client,
-        tags:   []string{"hystrixcircuit:" + name},
-      }
-    }
+		// there's no need to report the tag if it is already empty
+		if commandGroup == "" {
+			return &DatadogCollector{
+				client: client,
+				tags:   []string{"hystrixcircuit:" + name},
+			}
+		}
 		return &DatadogCollector{
 			client: client,
 			tags:   []string{"hystrixcircuit:" + name, "commandGroup:" + commandGroup},


### PR DESCRIPTION
1. make sure only set valid values like int > 0, str not empty
2. don't need to reset to default values if set is invalid
3. don't update queue size when max concurrent change
4. default command group should be empty
5. sort the setting keys in frequency order