### PR TITLE
Change AllowRequest logic to follow Netflix hystrix implementation 

### DIFF
--- a/hystrix/circuit.go
+++ b/hystrix/circuit.go
@@ -54,6 +54,18 @@ func GetCircuit(name string) (*CircuitBreaker, bool, error) {
 	return circuitBreakers[name], !ok, nil
 }
 
+// RemoveCircuit purges the given circuit from memory.
+func RemoveCircuit(name string) {
+	circuitBreakersMutex.Lock()
+	defer circuitBreakersMutex.Unlock()
+
+	if cb, ok := circuitBreakers[name]; ok {
+		cb.metrics.Reset()
+		cb.executorPool.Metrics.Reset()
+		delete(circuitBreakers, name)
+	}
+}
+
 // Flush purges all circuit and metric information from memory.
 func Flush() {
 	circuitBreakersMutex.Lock()

--- a/hystrix/circuit_test.go
+++ b/hystrix/circuit_test.go
@@ -1,13 +1,12 @@
 package hystrix
 
 import (
+	"math/rand"
 	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
-
-	"math/rand"
 	"testing/quick"
+	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -29,6 +28,34 @@ func TestGetCircuit(t *testing.T) {
 			_, created, err = GetCircuit("foo")
 			So(err, ShouldBeNil)
 			So(created, ShouldEqual, false)
+		})
+	})
+}
+
+func TestRemoveCircuit(t *testing.T) {
+	defer Flush()
+
+	Convey("when calling GetCircuit", t, func() {
+		var created bool
+		var err error
+		_, created, err = GetCircuit("foo")
+
+		Convey("once, the circuit should be created", func() {
+			So(err, ShouldBeNil)
+			So(created, ShouldEqual, true)
+		})
+
+		Convey("twice, the circuit should be reused", func() {
+			_, created, err = GetCircuit("foo")
+			So(err, ShouldBeNil)
+			So(created, ShouldEqual, false)
+		})
+
+		Convey("get after remove, the circuit should be created", func() {
+			RemoveCircuit("foo")
+			_, created, err = GetCircuit("foo")
+			So(err, ShouldBeNil)
+			So(created, ShouldEqual, true)
 		})
 	})
 }

--- a/hystrix/hystrix.go
+++ b/hystrix/hystrix.go
@@ -86,7 +86,7 @@ func Go(name string, run runFunc, fallback fallbackFunc) chan error {
 		// Circuits get opened when recent executions have shown to have a high error rate.
 		// Rejecting new executions allows backends to recover, and the circuit will allow
 		// new traffic when it feels a healthly state has returned.
-		if !cmd.circuit.AllowRequest() {
+		if !cmd.circuit.attemptExecution() {
 			cmd.errorWithFallback(ErrCircuitOpen)
 			close(cmd.ticketChecked)
 			return


### PR DESCRIPTION
Problem to resolve: 
> The current **AllowRequest** will perform a CAS on the openedOrLastTestedTime. Given a scenario where we want to perform a **AllowRequest** to determine if to use an external service before invoke the hystrix.Do/Go function for actual execution, once the circuit is open, the **AllowRequest** function in **hystrix.Do/Go** will always return ErrCircuitOpen since the openedOrLastTestedTime just been updated by the first **AllowRequest** call. 
>
> This can cause the circuit to always open without having chance to measure whether the external service has recovered. 

</br>
Observation: 

> The Netflix circuit breaker actually provide **allowRequest** and **attemptExecution** function to resolve this case. Where the **allowRequest** won't change circuit status and is used externally to pre-check if a service call should be permitted before the actual execution. For **attemptExecution**, it is used internally right before the execution to ensure only the first request is let through after each sleep window. 
<img width="673" alt="image" src="https://user-images.githubusercontent.com/21195851/185535610-01373220-eec7-4c39-97b0-1364ec5e2db3.png">

</br>
Fix: 

> This MR follow a similar implementation to update the existing **AllowRequest** function which could be used externally and add a **attemptExecution** to be used internally right before the actually execution in **hystrix.Do/Go**. This allows combination usage of **AllowRequest** and **hystrix.Do/Go**.
